### PR TITLE
Prevent exception when protecting root directory

### DIFF
--- a/RED2/Lib/TreeManager.cs
+++ b/RED2/Lib/TreeManager.cs
@@ -384,6 +384,8 @@ namespace RED2
 
         private void ProtectNode(TreeNode node)
         {
+            if (node != null)
+            {
             DirectoryInfo directory = (DirectoryInfo)node.Tag;
 
             if (nodePropsBackup.ContainsKey(directory.FullName))
@@ -404,6 +406,7 @@ namespace RED2
             // Recursively protect directories
             if (node.Parent != this.rootNode)
                 ProtectNode(node.Parent);
+            }
         }
 
         #endregion


### PR DESCRIPTION
Attempting to protect the root directory in the RED2 treeview could pass a NULL node to the ProtectNode method. check for NULL before processing.

I discovered RED2 a few months ago and have been making good use of it. Unfortunately it throws an exception if I action a 'Protect Once' on the root directory in the RED2 treeview. Ive fixed it in my local copy so I thought I'd try and give back a little by submitting the fix to you.

Robert 'NotBob' Bookerby